### PR TITLE
support null definitions in suites

### DIFF
--- a/specs/suite.spec.php
+++ b/specs/suite.spec.php
@@ -11,6 +11,13 @@ describe("Suite", function() {
        $this->eventEmitter = new EventEmitter();
     });
 
+    context("when constructed with null definition", function() {
+        it("it should default to a pending state", function() {
+            $suite = new Suite("should be pending");
+            assert($suite->getPending(), "suite should be pending if definition is null");
+        });
+    });
+
     describe('->run()', function() {
         it("should run multiple tests", function () {
             $suite = new Suite("Suite", function() {});

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -68,8 +68,15 @@ abstract class AbstractTest implements TestInterface
      * @param string   $description
      * @param callable $definition
      */
-    public function __construct($description, callable $definition)
+    public function __construct($description, callable $definition = null)
     {
+        if ($definition === null) {
+            $this->pending = true;
+            $definition = function () {
+                //noop
+            };
+        }
+
         $this->definition = $definition;
         $this->description = $description;
         $this->scope = new Scope();

--- a/src/Test.php
+++ b/src/Test.php
@@ -12,21 +12,6 @@ use Exception;
 class Test extends AbstractTest
 {
     /**
-     * @param string $description
-     * @param callable $definition
-     */
-    public function __construct($description, callable $definition = null)
-    {
-        if ($definition === null) {
-            $this->pending = true;
-            $definition = function () {
-                //noop
-            };
-        }
-        parent::__construct($description, $definition);
-    }
-
-    /**
      * Execute the test along with any setup and tear down functions.
      *
      * @param  TestResult $result


### PR DESCRIPTION
Anything inheriting from `AbstractTestCase` supports null definitions to default to a pending state.