### PR TITLE
add scopes back to core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "peridot-php/peridot-scope": "~1.1",
         "peridot-php/event-emitter": "2.0.*@dev"
     },
     "require-dev": {

--- a/specs/scope.spec.php
+++ b/specs/scope.spec.php
@@ -1,0 +1,190 @@
+<?php
+use Peridot\Core\Scope;
+
+describe('Scope', function() {
+    beforeEach(function() {
+        $this->scope = new Scope();
+    });
+
+    describe('->peridotAddChildScope()', function() {
+        it('should mixin behavior via __call', function() {
+            $this->scope->peridotAddChildScope(new TestScope());
+            $number = $this->scope->getNumber();
+            assert(5 === $number, 'getNumber() should return value');
+        });
+
+        it('should mixin properties via __get', function() {
+            $this->scope->peridotAddChildScope(new TestScope());
+            $name = $this->scope->name;
+            assert($name == "brian", "property should return value");
+        });
+
+        it('should set the parent scope property on child', function() {
+            $test = new TestScope();
+            $this->scope->peridotAddChildScope($test);
+            assert($test->peridotGetParentScope() === $this->scope, "should have set parent scope");
+        });
+    });
+
+    describe('->peridotBindTo()', function() {
+        it('should bind a Closure to the scope', function() {
+            $callable = function() {
+                return $this->name;
+            };
+            $scope = new TestScope();
+            $bound = $scope->peridotBindTo($callable);
+            $result = $bound();
+            assert($result == "brian", "scope should have been bound to callable");
+        });
+
+        it('should return non closures', function () {
+            $callable = 'strpos';
+            $scope = new TestScope();
+
+            $bound = $scope->peridotBindTo($callable);
+
+            assert($bound === 'strpos');
+        });
+    });
+
+    context("when calling a mixed in method", function() {
+        it('should throw an exception when method not found', function() {
+            $exception = null;
+            try {
+                $this->scope->nope();
+            } catch (\Exception $e) {
+                $exception = $e;
+            }
+            assert(!is_null($exception), 'exception should not be null');
+        });
+
+        context("and the desired method is on a child scope's child", function() {
+            it ("should look up method on the child scope's child", function() {
+                $testScope = new TestScope();
+                $testScope->peridotAddChildScope(new TestChildScope());
+                $this->scope->peridotAddChildScope($testScope);
+                $evenNumber = $this->scope->getEvenNumber();
+                assert($evenNumber === 4, "expected scope to look up child scope's child method");
+            });
+
+            context("when mixing in multiple scopes, one of which has a child", function() {
+                it ("should look up the child scope on the sibling", function() {
+                    $testScope = new TestScope();
+                    $testSibling = new TestSiblingScope();
+                    $testChild = new TestChildScope();
+                    $testSibling->peridotAddChildScope($testChild);
+                    $this->scope->peridotAddChildScope($testScope);
+                    $this->scope->peridotAddChildScope($testSibling);
+
+                    $number = $this->scope->getNumber();
+                    $evenNumber = $this->scope->getEvenNumber();
+                    $oddNumber = $this->scope->getOddNumber();
+
+                    assert($number === 5, "expected result of TestScope::getNumber()");
+                    assert($evenNumber === 4, "expected result of TestChildScope::getEvenNumber()");
+                    assert($oddNumber === 3, "expected result of TestSiblingScope::getOddNumber()");
+                });
+            });
+        });
+
+        context("when mixing in multiple scopes", function() {
+            it ("should look up methods for sibling scopes", function() {
+                $this->scope->peridotAddChildScope(new TestScope());
+                $this->scope->peridotAddChildScope(new TestChildScope());
+                $evenNumber = $this->scope->getEvenNumber();
+                $number = $this->scope->getNumber();
+                assert($evenNumber === 4, "expected scope to look up child method getEvenNumber()");
+                assert($number === 5, "expected scope to look up child method getNumber()");
+            });
+        });
+    });
+
+    context('when calling a mixed in property', function() {
+        it('should throw an exception when property not found', function() {
+            $exception = null;
+            try {
+                $this->scope->nope;
+            } catch (\Exception $e) {
+                $exception = $e;
+            }
+            assert(!is_null($exception), 'exception should not be null');
+        });
+
+        context("and the desired property is on a child scope's child", function() {
+            it ("should look up property on the child scope's child", function() {
+                $testScope = new TestScope();
+                $testScope->peridotAddChildScope(new TestChildScope());
+                $this->scope->peridotAddChildScope($testScope);
+                $surname = $this->scope->surname;
+                assert($surname === "scaturro", "expected scope to look up child scope's child property");
+            });
+
+            context("when mixing in multiple scopes, one of which has a child", function() {
+                it ("should look up the child scope on the sibling", function() {
+                    $testScope = new TestScope();
+                    $testSibling = new TestSiblingScope();
+                    $testChild = new TestChildScope();
+                    $testSibling->peridotAddChildScope($testChild);
+                    $this->scope->peridotAddChildScope($testScope);
+                    $this->scope->peridotAddChildScope($testSibling);
+
+                    $name = $this->scope->name;
+                    $middle = $this->scope->middleName;
+                    $surname = $this->scope->surname;
+
+                    assert($name === "brian", "expected result of TestScope::name");
+                    assert($middle == "zooooom", "expected result of TestSiblingScope::middleName");
+                    assert($surname === "scaturro", "expected result of TestChildScope::surname");
+                });
+            });
+        });
+
+        context("when mixing in multiple scopes", function() {
+            it ("should look up properties for sibling scopes", function() {
+                $this->scope->peridotAddChildScope(new TestScope());
+                $this->scope->peridotAddChildScope(new TestChildScope());
+                $name = $this->scope->name;
+                $surname = $this->scope->surname;
+                assert($name === "brian", "expected result of TestScope::name");
+                assert($surname === "scaturro", "expected result of TestChildScope::surname");
+            });
+        });
+    });
+});
+
+class TestScope extends Scope
+{
+    public $name = "brian";
+
+    public $data;
+
+    public function __construct()
+    {
+        $this->data = ['one' => 1, 'two' => 2];
+    }
+
+    public function getNumber()
+    {
+        return 5;
+    }
+}
+
+class TestChildScope extends Scope
+{
+    public $surname = "scaturro";
+
+    public function getEvenNumber()
+    {
+        return 4;
+    }
+}
+
+class TestSiblingScope extends Scope
+{
+    public $middleName = "zooooom";
+
+    public function getOddNumber()
+    {
+        return 3;
+    }
+}

--- a/specs/suite.spec.php
+++ b/specs/suite.spec.php
@@ -3,7 +3,7 @@ use Peridot\EventEmitter;
 use Peridot\Core\Test;
 use Peridot\Core\TestResult;
 use Peridot\Core\Suite;
-use Peridot\Scope\Scope;
+use Peridot\Core\Scope;
 
 describe("Suite", function() {
 

--- a/specs/test.spec.php
+++ b/specs/test.spec.php
@@ -3,7 +3,7 @@ use Peridot\EventEmitter;
 use Peridot\Core\Test;
 use Peridot\Core\TestResult;
 use Peridot\Core\Suite;
-use Peridot\Scope\Scope;
+use Peridot\Core\Scope;
 
 describe("Test", function() {
 

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -2,8 +2,6 @@
 
 namespace Peridot\Core;
 
-use Peridot\Scope\Scope;
-
 /**
  * Base class for Peridot Suites and Tests
  *

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -1,0 +1,138 @@
+<?php
+namespace Peridot\Core;
+
+use BadMethodCallException;
+use Closure;
+use DomainException;
+
+/**
+ * Property bag for scoping "instance variables" and mixing in
+ * behavior and state
+ *
+ * @package Peridot\Core
+ */
+class Scope
+{
+    /**
+     * @var \SplObjectStorage
+     */
+    protected $peridotChildScopes;
+
+    /**
+     * @var Scope
+     */
+    protected $peridotParentScope;
+
+    /**
+     * @param Scope $scope
+     */
+    public function peridotAddChildScope(Scope $scope)
+    {
+        $scope->peridotSetParentScope($this);
+        $this->peridotGetChildScopes()->attach($scope);
+    }
+
+    /**
+     * @return Scope
+     */
+    public function peridotGetParentScope()
+    {
+        return $this->peridotParentScope;
+    }
+
+    /**
+     * @param Scope $peridotParentScope
+     */
+    public function peridotSetParentScope($peridotParentScope)
+    {
+        $this->peridotParentScope = $peridotParentScope;
+        return $this;
+    }
+
+    /**
+     * @return \SplObjectStorage
+     */
+    public function peridotGetChildScopes()
+    {
+        if (!isset($this->peridotChildScopes)) {
+            $this->peridotChildScopes = new \SplObjectStorage();
+        }
+        return $this->peridotChildScopes;
+    }
+
+    /**
+     * Bind a callable to the scope.
+     *
+     * @param callable $callable
+     * @return callable
+     */
+    public function peridotBindTo(callable $callable)
+    {
+        if ($callable instanceof Closure) {
+            return Closure::bind($callable, $this, $this);
+        }
+        return $callable;
+    }
+
+    /**
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     * @throw BadMethodCallException
+     */
+    public function __call($name, $arguments)
+    {
+        list($result, $found) = $this->peridotScanChildren($this, function ($childScope, &$accumulator) use ($name, $arguments) {
+            if (method_exists($childScope, $name)) {
+                $accumulator = [call_user_func_array([$childScope, $name], $arguments), true];
+            }
+        });
+        if (!$found) {
+            throw new BadMethodCallException("Scope method $name not found");
+        }
+        return $result;
+    }
+
+    /**
+     * Lookup properties on child scopes.
+     *
+     * @param $name
+     * @return mixed
+     * @throws DomainException
+     */
+    public function &__get($name)
+    {
+        list($result, $found) = $this->peridotScanChildren($this, function ($childScope, &$accumulator) use ($name) {
+            if (property_exists($childScope, $name)) {
+                $accumulator = [$childScope->$name, true, $childScope];
+            }
+        });
+        if (!$found) {
+            throw new DomainException("Scope property $name not found");
+        }
+        return $result;
+    }
+
+    /**
+     * Scan child scopes and execute a function against each one passing an
+     * accumulator reference along.
+     *
+     * @param Scope $scope
+     * @param callable $fn
+     * @param array $accumulator
+     * @return array
+     */
+    protected function peridotScanChildren(Scope $scope, callable $fn, &$accumulator = [])
+    {
+        if (! empty($accumulator)) {
+            return $accumulator;
+        }
+
+        $children = $scope->peridotGetChildScopes();
+        foreach ($children as $childScope) {
+            $fn($childScope, $accumulator);
+            $this->peridotScanChildren($childScope, $fn, $accumulator);
+        }
+        return $accumulator;
+    }
+}

--- a/src/TestInterface.php
+++ b/src/TestInterface.php
@@ -1,7 +1,6 @@
 <?php
 namespace Peridot\Core;
 
-use Peridot\Scope\Scope;
 use Peridot\EventEmitterInterface;
 
 /**


### PR DESCRIPTION
Scopes really should be brought back to core. They are sort of a novel idea outside of core, but not very useful. It would be easier to develop such an important part of core behavior if it was in the same repo. I am thinking this will also benefit the project once some serious scope refactorings take place soon.