### PR TITLE
Add behaviors to Core

### DIFF
--- a/specs/behavior/listener.spec.php
+++ b/specs/behavior/listener.spec.php
@@ -1,0 +1,28 @@
+<?php
+use Peridot\Core\Behavior\Listener;
+use Peridot\EventEmitter;
+use Peridot\Core\Test;
+use Peridot\Core\TestResult;
+use Peridot\Core\Exception\PendingException;
+
+describe('Listener', function () {
+    beforeEach(function () {
+        $this->emitter = new EventEmitter();
+        $this->listener = new Listener($this->emitter);
+        $this->listener->listen();
+    });
+
+    context('when a test.start event is emitted', function () {
+        it('should add the StateBehavior to the test', function () {
+            $ex = null;
+            $test = new Test('sample test', function () {
+                $this->pend();
+            });
+            $result = new TestResult($this->emitter);
+            $this->emitter->emit('test.start', $test);
+            $test->run($result);
+            
+            assert($test->getPending(), 'test should be pending');
+        });
+    });
+});

--- a/specs/behavior/state-behavior.spec.php
+++ b/specs/behavior/state-behavior.spec.php
@@ -1,0 +1,36 @@
+<?php
+use Peridot\Core\Test;
+use Peridot\Core\Behavior\StateBehavior;
+use Peridot\Core\Exception\PendingException;
+
+describe('StateBehavior', function () {
+    beforeEach(function () {
+        $this->test = new Test('test');
+        $this->behavior = new StateBehavior($this->test);
+    });
+
+    describe('->pend()', function () {
+        it('should throw a pending exception and set the test to pending', function () {
+            $ex = null;
+            try {
+                $this->behavior->pend();
+            } catch (PendingException $e) {
+                $ex = $e;
+            }
+            assert($ex instanceof PendingException, 'exception should be a PendingException');
+            assert($this->test->getPending(), 'test should be pending');
+        });
+    });
+
+    describe('->fail()', function () {
+        it('throws an exception with a given message', function () {
+            $ex = null;
+            try {
+                $this->behavior->fail('failure!!');
+            } catch (Exception $e) {
+                $ex = $e;
+            }
+            assert($ex->getMessage() === 'failure!!');
+        });
+    });
+});

--- a/specs/test.spec.php
+++ b/specs/test.spec.php
@@ -4,6 +4,7 @@ use Peridot\Core\Test;
 use Peridot\Core\TestResult;
 use Peridot\Core\Suite;
 use Peridot\Core\Scope;
+use Peridot\Core\Exception\PendingException;
 
 describe("Test", function() {
 
@@ -98,6 +99,15 @@ describe("Test", function() {
 
             $test->run(new TestResult(new EventEmitter()));
             assert(empty($test->getScope()->log), 'test should have been skipped');
+        });
+
+        it('should add a pending result if a PendingException is thrown', function () {
+            $test = new Test('should pend', function () {
+                throw new PendingException();
+            });
+            $result = new TestResult(new EventEmitter());
+            $test->run($result);
+            assert("1 run, 0 failed, 1 pending" == $result->getSummary());
         });
 
         context("when test is pending", function() {

--- a/src/Behavior/Listener.php
+++ b/src/Behavior/Listener.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Peridot\Core\Behavior;
+
+use Peridot\EventEmitterInterface;
+use Peridot\Core\TestInterface;
+
+/**
+ * An event listener that registers behaviors with relevant
+ * events in the Peridot test life cycle
+ */
+class Listener
+{
+    /**
+     * @var EventEmitterInterface;
+     */
+    protected $emitter;
+
+    /**
+     * @param EventEmitterInterface $emitter
+     */
+    public function __construct(EventEmitterInterface $emitter)
+    {
+        $this->emitter = $emitter;
+    }
+
+    /**
+     * Listen for events and add behaviors
+     *
+     * @return void
+     */
+    public function listen()
+    {
+        $this->emitter->on('test.start', [$this, 'onTestStart']);
+    }
+
+    /**
+     * Add behaviors relevant when a test is executed
+     *
+     * @param TestInterface $test
+     * @return void
+     */
+    public function onTestStart(TestInterface $test)
+    {
+        $scope = $test->getScope();
+        $behavior = new StateBehavior($test);
+        $scope->peridotAddChildScope($behavior);
+    }
+}

--- a/src/Behavior/StateBehavior.php
+++ b/src/Behavior/StateBehavior.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Peridot\Core\Behavior;
+
+use Peridot\Core\Scope;
+use Peridot\Core\Exception\PendingException;
+use Peridot\Core\TestInterface;
+
+/**
+ * The StateBehavior adds behavior for controlling test state
+ *
+ * @package Peridot\Core\Behavior
+ */
+class StateBehavior extends Scope
+{
+    /**
+     * @var \Peridot\Core\TestInterface
+     */
+    protected $test;
+
+    /**
+     * @param \Peridot\Core\TestInterface
+     */
+    public function __construct(TestInterface $test)
+    {
+        $this->test = $test;
+    }
+
+    /**
+     * Put the test into a pending state. Halts test execution when
+     * called
+     *
+     * @throws \Peridot\Core\Exception\PendingException
+     */
+    public function pend()
+    {
+        $this->test->setPending(true);
+        throw new PendingException();
+    }
+
+    /**
+     * Fail the test
+     *
+     * @param string $message
+     * @throws \Exception
+     */
+    public function fail($message)
+    {
+        throw new \Exception($message);
+    }
+}

--- a/src/Exception/PendingException.php
+++ b/src/Exception/PendingException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Peridot\Core\Exception;
+
+use Peridot\Core\Exception as PeridotException;
+
+/**
+ * Used to halt execution of a teste and put it into a pending state
+ *
+ * @package Peridot\Core\Exception
+ */
+class PendingException extends PeridotException { }

--- a/src/Test.php
+++ b/src/Test.php
@@ -2,6 +2,7 @@
 
 namespace Peridot\Core;
 
+use Peridot\Core\Exception\PendingException;
 use Exception;
 
 /**
@@ -25,6 +26,7 @@ class Test extends AbstractTest
             $result->pendTest($this);
             return;
         }
+        
         $this->executeTest($result);
         $result->endTest($this);
     }
@@ -40,6 +42,8 @@ class Test extends AbstractTest
         try {
             $this->runSetup();
             call_user_func_array($this->getDefinition(), $this->getDefinitionArguments());
+        } catch (PendingException $e) {
+            $action = ['pendTest', $this];
         } catch (Exception $e) {
             $action = ['failTest', $this, $e];
         }


### PR DESCRIPTION
The concept of behaviors just means `Scope` objects that are part of the Peridot core. They are meant to extend core objects with behavior that should be available to all tests.

In this case, a `StateBehavior` is introduced to allow a test to control its own state. It adds a `pend()` method for forcing the test into a pending state. It also includes a `fail()` method for manually triggering a failure. `StateBehavior` addresses #4 

The `Listener` object is included to make baking this core behaviors in easier. Since a goal for Peridot 2.0 is to bake in core modules and behaviors, this `Listener` will be used via the same mechanism that these core plugins are included.