### PR TITLE
Scope enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.idea

--- a/specs/scope.spec.php
+++ b/specs/scope.spec.php
@@ -6,65 +6,65 @@ describe('Scope', function() {
         $this->scope = new Scope();
     });
 
-    describe('->peridotAddChildScope()', function() {
+    describe('->addChildScope()', function() {
         it('should mixin behavior via __call', function() {
-            $this->scope->peridotAddChildScope(new TestScope());
+            $this->scope->addChildScope(new TestScope());
             $number = $this->scope->getNumber();
             assert(5 === $number, 'getNumber() should return value');
         });
 
         it('should mixin properties via __get', function() {
-            $this->scope->peridotAddChildScope(new TestScope());
+            $this->scope->addChildScope(new TestScope());
             $name = $this->scope->name;
             assert($name == "brian", "property should return value");
         });
 
         it('should set the parent scope property on child', function() {
             $test = new TestScope();
-            $this->scope->peridotAddChildScope($test);
-            assert($test->peridotGetParentScope() === $this->scope, "should have set parent scope");
+            $this->scope->addChildScope($test);
+            assert($test->getParentScope() === $this->scope, "should have set parent scope");
         });
 
         it('can supply a key for the child scope', function () {
             $test = new TestScope();
-            $this->scope->peridotAddChildScope($test, 'test');
-            $scope = $this->scope->peridotGetChildScope('test');
+            $this->scope->addChildScope($test, 'test');
+            $scope = $this->scope->getChildScope('test');
             assert($scope === $test);
         });
     });
 
-    describe('->peridotHasChildScope()', function () {
+    describe('->hasChildScope()', function () {
         it('returns true if a child scope with the given key exists', function () {
             $test = new TestScope();
-            $this->scope->peridotAddChildScope($test, 'test');
-            assert($this->scope->peridotHasChildScope('test'));
+            $this->scope->addChildScope($test, 'test');
+            assert($this->scope->hasChildScope('test'));
         });
 
         it('returns false if a child scope with the given key does not exist', function () {
-            assert($this->scope->peridotHasChildScope('test') === false);
+            assert($this->scope->hasChildScope('test') === false);
         });
     });
 
-    describe('->peridotRemoveChildScope()', function () {
+    describe('->removeChildScope()', function () {
         it('returns true if it removes a child scope successfully', function () {
             $test = new TestScope();
-            $this->scope->peridotAddChildScope($test, 'test');
-            $removed = $this->scope->peridotRemoveChildScope('test');
+            $this->scope->addChildScope($test, 'test');
+            $removed = $this->scope->removeChildScope('test');
             assert($removed);
         });
 
         it('returns false if it did not remove a scope', function () {
-            assert($this->scope->peridotRemoveChildScope('test') === false);
+            assert($this->scope->removeChildScope('test') === false);
         });
     });
 
-    describe('->peridotBindTo()', function() {
+    describe('->bindTo()', function() {
         it('should bind a Closure to the scope', function() {
             $callable = function() {
                 return $this->name;
             };
             $scope = new TestScope();
-            $bound = $scope->peridotBindTo($callable);
+            $bound = $scope->bindTo($callable);
             $result = $bound();
             assert($result == "brian", "scope should have been bound to callable");
         });
@@ -73,7 +73,7 @@ describe('Scope', function() {
             $callable = 'strpos';
             $scope = new TestScope();
 
-            $bound = $scope->peridotBindTo($callable);
+            $bound = $scope->bindTo($callable);
 
             assert($bound === 'strpos');
         });
@@ -93,8 +93,8 @@ describe('Scope', function() {
         context("and the desired method is on a child scope's child", function() {
             it ("should look up method on the child scope's child", function() {
                 $testScope = new TestScope();
-                $testScope->peridotAddChildScope(new TestChildScope());
-                $this->scope->peridotAddChildScope($testScope);
+                $testScope->addChildScope(new TestChildScope());
+                $this->scope->addChildScope($testScope);
                 $evenNumber = $this->scope->getEvenNumber();
                 assert($evenNumber === 4, "expected scope to look up child scope's child method");
             });
@@ -104,9 +104,9 @@ describe('Scope', function() {
                     $testScope = new TestScope();
                     $testSibling = new TestSiblingScope();
                     $testChild = new TestChildScope();
-                    $testSibling->peridotAddChildScope($testChild);
-                    $this->scope->peridotAddChildScope($testScope);
-                    $this->scope->peridotAddChildScope($testSibling);
+                    $testSibling->addChildScope($testChild);
+                    $this->scope->addChildScope($testScope);
+                    $this->scope->addChildScope($testSibling);
 
                     $number = $this->scope->getNumber();
                     $evenNumber = $this->scope->getEvenNumber();
@@ -121,8 +121,8 @@ describe('Scope', function() {
 
         context("when mixing in multiple scopes", function() {
             it ("should look up methods for sibling scopes", function() {
-                $this->scope->peridotAddChildScope(new TestScope());
-                $this->scope->peridotAddChildScope(new TestChildScope());
+                $this->scope->addChildScope(new TestScope());
+                $this->scope->addChildScope(new TestChildScope());
                 $evenNumber = $this->scope->getEvenNumber();
                 $number = $this->scope->getNumber();
                 assert($evenNumber === 4, "expected scope to look up child method getEvenNumber()");
@@ -145,8 +145,8 @@ describe('Scope', function() {
         context("and the desired property is on a child scope's child", function() {
             it ("should look up property on the child scope's child", function() {
                 $testScope = new TestScope();
-                $testScope->peridotAddChildScope(new TestChildScope());
-                $this->scope->peridotAddChildScope($testScope);
+                $testScope->addChildScope(new TestChildScope());
+                $this->scope->addChildScope($testScope);
                 $surname = $this->scope->surname;
                 assert($surname === "scaturro", "expected scope to look up child scope's child property");
             });
@@ -156,9 +156,9 @@ describe('Scope', function() {
                     $testScope = new TestScope();
                     $testSibling = new TestSiblingScope();
                     $testChild = new TestChildScope();
-                    $testSibling->peridotAddChildScope($testChild);
-                    $this->scope->peridotAddChildScope($testScope);
-                    $this->scope->peridotAddChildScope($testSibling);
+                    $testSibling->addChildScope($testChild);
+                    $this->scope->addChildScope($testScope);
+                    $this->scope->addChildScope($testSibling);
 
                     $name = $this->scope->name;
                     $middle = $this->scope->middleName;
@@ -173,8 +173,8 @@ describe('Scope', function() {
 
         context("when mixing in multiple scopes", function() {
             it ("should look up properties for sibling scopes", function() {
-                $this->scope->peridotAddChildScope(new TestScope());
-                $this->scope->peridotAddChildScope(new TestChildScope());
+                $this->scope->addChildScope(new TestScope());
+                $this->scope->addChildScope(new TestChildScope());
                 $name = $this->scope->name;
                 $surname = $this->scope->surname;
                 assert($name === "brian", "expected result of TestScope::name");

--- a/specs/scope.spec.php
+++ b/specs/scope.spec.php
@@ -79,6 +79,29 @@ describe('Scope', function() {
         });
     });
 
+    describe('->inheritScope()', function () {
+        it('should copy properties from another scope', function () {
+            $src = new Scope();
+            $src->name = 'brian';
+            $target = new Scope();
+
+            $target->inheritScope($src);
+
+            assert($target->name === 'brian');
+        });
+
+        it('should not copy properties from another scope if they are already set', function () {
+            $src = new Scope();
+            $src->name = 'brian';
+            $target = new Scope();
+            $target->name = 'phil';
+
+            $target->inheritScope($src);
+
+            assert($target->name === 'phil');
+        });
+    });
+
     context("when calling a mixed in method", function() {
         it('should throw an exception when method not found', function() {
             $exception = null;
@@ -140,6 +163,18 @@ describe('Scope', function() {
                 $exception = $e;
             }
             assert(!is_null($exception), 'exception should not be null');
+        });
+
+        context('and the desired property is on a parent scope', function () {
+            it('should look up the property on the scope parent', function () {
+                $parent = new Scope();
+                $child = new Scope();
+                $parent->parentProperty = 'value';
+
+                $parent->addChildScope($child);
+
+                assert($child->parentProperty === 'value', 'expected child to be able to look at parent scope');
+            });
         });
 
         context("and the desired property is on a child scope's child", function() {

--- a/specs/suite.spec.php
+++ b/specs/suite.spec.php
@@ -55,7 +55,7 @@ describe("Suite", function() {
 
         it('should pass child scopes to tests', function() {
             $suite = new Suite("Suite", function() {});
-            $suite->getScope()->peridotAddChildScope(new SuiteScope());
+            $suite->getScope()->addChildScope(new SuiteScope());
             $test = new Test("this is a test", function() {
                 assert($this->getNumber() == 5, "parent scope should be set on test");
             });

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -87,7 +87,7 @@ abstract class AbstractTest implements TestInterface
      */
     public function addSetupFunction(callable $setupFn)
     {
-        $fn = $this->getScope()->peridotBindTo($setupFn);
+        $fn = $this->getScope()->bindTo($setupFn);
         array_push($this->setUpFns, $fn);
     }
 
@@ -98,7 +98,7 @@ abstract class AbstractTest implements TestInterface
      */
     public function addTearDownFunction(callable $tearDownFn)
     {
-        $fn = $this->getScope()->peridotBindTo($tearDownFn);
+        $fn = $this->getScope()->bindTo($tearDownFn);
         array_push($this->tearDownFns, $fn);
     }
 
@@ -119,7 +119,7 @@ abstract class AbstractTest implements TestInterface
      */
     public function getDefinition()
     {
-        return $this->scope->peridotBindTo($this->definition);
+        return $this->scope->bindTo($this->definition);
     }
 
     /**

--- a/src/Behavior/Listener.php
+++ b/src/Behavior/Listener.php
@@ -44,6 +44,6 @@ class Listener
     {
         $scope = $test->getScope();
         $behavior = new StateBehavior($test);
-        $scope->peridotAddChildScope($behavior);
+        $scope->addChildScope($behavior);
     }
 }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -27,9 +27,9 @@ class Scope
      * @param Scope $scope
      * @param string $key - an optional key. defaults to the scope's object hash
      */
-    public function peridotAddChildScope(Scope $scope, $key = "")
+    public function addChildScope(Scope $scope, $key = "")
     {
-        $scope->peridotSetParentScope($this);
+        $scope->setParentScope($this);
         if (empty($key)) {
             $key = spl_object_hash($scope);
         }
@@ -39,7 +39,7 @@ class Scope
     /**
      * @return Scope
      */
-    public function peridotGetParentScope()
+    public function getParentScope()
     {
         return $this->peridotParentScope;
     }
@@ -47,7 +47,7 @@ class Scope
     /**
      * @param Scope $peridotParentScope
      */
-    public function peridotSetParentScope($peridotParentScope)
+    public function setParentScope($peridotParentScope)
     {
         $this->peridotParentScope = $peridotParentScope;
         return $this;
@@ -56,7 +56,7 @@ class Scope
     /**
      * @return array
      */
-    public function peridotGetChildScopes()
+    public function getChildScopes()
     {
         return $this->peridotChildScopes;
     }
@@ -67,7 +67,7 @@ class Scope
      * @param string $key
      * @return bool
      */
-    public function peridotHasChildScope($key)
+    public function hasChildScope($key)
     {
         if (isset($this->peridotChildScopes[$key])) {
             return true;
@@ -80,9 +80,9 @@ class Scope
      *
      * @return Scope|null
      */
-    public function peridotGetChildScope($key)
+    public function getChildScope($key)
     {
-        if ($this->peridotHasChildScope($key)) {
+        if ($this->hasChildScope($key)) {
             return $this->peridotChildScopes[$key];
         }
         return null;
@@ -94,9 +94,9 @@ class Scope
      * @param string $key
      * @return bool
      */
-    public function peridotRemoveChildScope($key)
+    public function removeChildScope($key)
     {
-        if ($this->peridotHasChildScope($key)) {
+        if ($this->hasChildScope($key)) {
             unset($this->peridotChildScopes[$key]);
             return true;
         }
@@ -109,7 +109,7 @@ class Scope
      * @param callable $callable
      * @return callable
      */
-    public function peridotBindTo(callable $callable)
+    public function bindTo(callable $callable)
     {
         if ($callable instanceof Closure) {
             return Closure::bind($callable, $this, $this);
@@ -125,7 +125,7 @@ class Scope
      */
     public function __call($name, $arguments)
     {
-        list($result, $found) = $this->peridotScanChildren($this, function ($childScope, &$accumulator) use ($name, $arguments) {
+        list($result, $found) = $this->scanChildren($this, function ($childScope, &$accumulator) use ($name, $arguments) {
             if (method_exists($childScope, $name)) {
                 $accumulator = [call_user_func_array([$childScope, $name], $arguments), true];
             }
@@ -145,7 +145,7 @@ class Scope
      */
     public function &__get($name)
     {
-        list($result, $found) = $this->peridotScanChildren($this, function ($childScope, &$accumulator) use ($name) {
+        list($result, $found) = $this->scanChildren($this, function ($childScope, &$accumulator) use ($name) {
             if (property_exists($childScope, $name)) {
                 $accumulator = [$childScope->$name, true, $childScope];
             }
@@ -165,16 +165,16 @@ class Scope
      * @param array $accumulator
      * @return array
      */
-    protected function peridotScanChildren(Scope $scope, callable $fn, &$accumulator = [])
+    protected function scanChildren(Scope $scope, callable $fn, &$accumulator = [])
     {
         if (! empty($accumulator)) {
             return $accumulator;
         }
 
-        $children = $scope->peridotGetChildScopes();
+        $children = $scope->getChildScopes();
         foreach ($children as $childScope) {
             $fn($childScope, $accumulator);
-            $this->peridotScanChildren($childScope, $fn, $accumulator);
+            $this->scanChildren($childScope, $fn, $accumulator);
         }
         return $accumulator;
     }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -47,9 +47,10 @@ class Scope
     /**
      * @param Scope $peridotParentScope
      */
-    public function setParentScope($peridotParentScope)
+    public function setParentScope(Scope $peridotParentScope)
     {
         $this->peridotParentScope = $peridotParentScope;
+        $this->inheritScope($peridotParentScope);
         return $this;
     }
 
@@ -154,6 +155,23 @@ class Scope
             throw new DomainException("Scope property $name not found");
         }
         return $result;
+    }
+
+    /**
+     * Copy properties from another scope
+     *
+     * @param Scope $scope
+     * @return void
+     */
+    public function inheritScope(Scope $scope)
+    {
+        $properties = get_object_vars($scope);
+
+        foreach ($properties as $property => $value) {
+            if (!isset($this->$property)) {
+                $this->$property = $value;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR does the following:

* Gets rid of the awkward prefixing of scope methods - instead of `peridotAddChildScope`, we simply have `addChildScope`
* Adds `Scope::inheritScope()` - this method allows one scope to copy state from another
* `Scope::setParentScope()` calls `Scope::inheritScope` on the child to inherit from the parent - this should allow scopes to function more like traits in that they can now read parent state