### PR TITLE
Feature node methods

### DIFF
--- a/specs/node.spec.php
+++ b/specs/node.spec.php
@@ -1,0 +1,43 @@
+<?php
+use Peridot\Core\Suite;
+use Peridot\Core\Test;
+
+describe('NodeInterface', function () {
+
+    beforeEach(function () {
+        $this->node = new Suite('node');
+    });
+
+    describe('->removeNode()', function () {
+        it('should remove the child node and return it', function () {
+            $first = new Test('child 1');
+            $second = new Test('child 2');
+            $this->node->setChildNodes([$first, $second]);
+
+            $removed = $this->node->removeNode($first);
+
+            assert($removed === $first, 'should have returned removed node');
+            assert(count($this->node->getChildNodes()) === 1, 'size should reflect removed node');
+        });
+
+        it('should return null if node not removed', function () {
+            $first = new Test('child');
+
+            $removed = $this->node->removeNode($first);
+
+            assert($removed === null, 'cannot remove node that is not child');
+        });
+
+        it('should be possible through parent references', function () {
+            $first = new Test('child 1');
+            $second = new Test('child 2');
+            $this->node->setChildNodes([$first, $second]);
+
+            $removed = $first->getParent()->removeNode($first);
+
+            assert($removed === $first, 'should have returned removed node');
+            assert(count($this->node->getChildNodes()) === 1, 'size should reflect removed node');
+        });
+    });
+
+});

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -10,7 +10,9 @@ namespace Peridot\Core;
 abstract class AbstractTest implements TestInterface
 {
     use HasEventEmitterTrait;
-    use NodeTrait;
+    use NodeTrait {
+        setParent as setParentNode;
+    }
 
     /**
      * The test definition as a callable.
@@ -37,11 +39,6 @@ abstract class AbstractTest implements TestInterface
      * @var string
      */
     protected $description;
-
-    /**
-     * @var TestInterface
-     */
-    protected $parent;
 
     /**
      * @var bool|null
@@ -131,18 +128,8 @@ abstract class AbstractTest implements TestInterface
      */
     public function setParent(TestInterface $parent)
     {
-        $this->parent = $parent;
+        $this->setParentNode($parent);
         $this->setScope($parent->getScope());
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return TestInterface
-     */
-    public function getParent()
-    {
-        return $this->parent;
     }
 
     /**

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -10,6 +10,7 @@ namespace Peridot\Core;
 abstract class AbstractTest implements TestInterface
 {
     use HasEventEmitterTrait;
+    use NodeTrait;
 
     /**
      * The test definition as a callable.
@@ -199,38 +200,6 @@ abstract class AbstractTest implements TestInterface
     public function getTearDownFunctions()
     {
         return $this->tearDownFns;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param callable $fn
-     */
-    public function walkUp(callable $fn)
-    {
-        $node = $this;
-        while ($node !== null) {
-            $fn($node);
-            $node = $node->getParent();
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param callable $fn
-     */
-    public function walkDown(callable $fn)
-    {
-        $node = $this;
-        $nodes = [];
-        while ($node !== null) {
-            array_unshift($nodes, $node);
-            $node = $node->getParent();
-        }
-        foreach ($nodes as $node) {
-            $fn($node);
-        }
     }
 
     /**

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -126,10 +126,12 @@ abstract class AbstractTest implements TestInterface
      * @param  TestInterface $parent
      * @return mixed|void
      */
-    public function setParent(TestInterface $parent)
+    public function setParent(NodeInterface $parent)
     {
         $this->setParentNode($parent);
-        $this->setScope($parent->getScope());
+        if ($parent instanceof TestInterface) {
+            $this->setScope($parent->getScope());
+        }
     }
 
     /**

--- a/src/AbstractTest.php
+++ b/src/AbstractTest.php
@@ -206,7 +206,7 @@ abstract class AbstractTest implements TestInterface
      *
      * @param callable $fn
      */
-    public function forEachNodeBottomUp(callable $fn)
+    public function walkUp(callable $fn)
     {
         $node = $this;
         while ($node !== null) {
@@ -220,7 +220,7 @@ abstract class AbstractTest implements TestInterface
      *
      * @param callable $fn
      */
-    public function forEachNodeTopDown(callable $fn)
+    public function walkDown(callable $fn)
     {
         $node = $this;
         $nodes = [];

--- a/src/NodeInterface.php
+++ b/src/NodeInterface.php
@@ -2,6 +2,11 @@
 
 namespace Peridot\Core;
 
+/**
+ * NodeInterface provides methods for setting node relationships and tree traversal
+ *
+ * @package Peridot\Core
+ */
 interface NodeInterface
 {
     /**
@@ -21,18 +26,44 @@ interface NodeInterface
     public function walkDown(callable $fn);
 
     /**
-     * @return TestInterface
+     * Get the parent node
+     *
+     * @return NodeInterface
      */
     public function getParent();
 
     /**
+     * Set the parent node
+     *
      * @param  TestInterface $parent
      * @return mixed
      */
-    public function setParent(TestInterface $parent);
+    public function setParent(NodeInterface $parent);
 
     /**
+     * Get all child nodes
+     *
      * @return NodeInterface[]
      */
     public function getChildNodes();
+
+    /**
+     * Set child nodes
+     *
+     * @param array $nodes
+     */
+    public function setChildNodes(array $nodes);
+
+    /**
+     * @param NodeInterface $node
+     */
+    public function addChildNode(NodeInterface $node);
+
+    /**
+     * Remove the given child node and return it
+     *
+     * @param NodeInterface $node
+     * @return NodeInterface|null
+     */
+    public function removeNode(NodeInterface $node);
 }

--- a/src/NodeInterface.php
+++ b/src/NodeInterface.php
@@ -30,4 +30,9 @@ interface NodeInterface
      * @return mixed
      */
     public function setParent(TestInterface $parent);
+
+    /**
+     * @return NodeInterface[]
+     */
+    public function getChildNodes();
 }

--- a/src/NodeInterface.php
+++ b/src/NodeInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Peridot\Core;
+
+interface NodeInterface
+{
+    /**
+     * Execute a callback for each child node, starting
+     * at the bottom of the tree.
+     *
+     * @param callable $fn
+     */
+    public function walkUp(callable $fn);
+
+    /**
+     * Execute a callback for each child node, starting
+     * at the top of the tree.
+     *
+     * @param callable $fn
+     */
+    public function walkDown(callable $fn);
+
+    /**
+     * @return TestInterface
+     */
+    public function getParent();
+
+    /**
+     * @param  TestInterface $parent
+     * @return mixed
+     */
+    public function setParent(TestInterface $parent);
+}

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Peridot\Core;
+
+/**
+ * NodeTrait provides tree traversal and node based operations to tree-like structures - i.e the Peridot TestInterface
+ *
+ * @package Peridot\Core
+ */
+trait NodeTrait
+{
+    /**
+     * @return TestInterface
+     */
+    public function getNode()
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param callable $fn
+     */
+    public function walkUp(callable $fn)
+    {
+        $node = $this->getNode();
+        while ($node !== null) {
+            $fn($node);
+            $node = $node->getParent();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param callable $fn
+     */
+    public function walkDown(callable $fn)
+    {
+        $node = $this->getNode();
+        $nodes = [];
+        while ($node !== null) {
+            array_unshift($nodes, $node);
+            $node = $node->getParent();
+        }
+        foreach ($nodes as $node) {
+            $fn($node);
+        }
+    }
+}

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -10,11 +10,24 @@ namespace Peridot\Core;
 trait NodeTrait
 {
     /**
+     * @var array
+     */
+    protected $childNodes = [];
+
+    /**
      * @return NodeInterface
      */
     public function getNode()
     {
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getChildNodes()
+    {
+        return $this->childNodes;
     }
 
     /**

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -28,11 +28,31 @@ trait NodeTrait
     }
 
     /**
+     * @param NodeInterface $node
+     */
+    public function addChildNode(NodeInterface $node)
+    {
+        $node->setParent($this->getNode());
+        $this->childNodes[] = $node;
+    }
+
+    /**
      * @return array
      */
     public function getChildNodes()
     {
         return $this->childNodes;
+    }
+
+    /**
+     * @param array $nodes
+     */
+    public function setChildNodes(array $nodes)
+    {
+        $this->childNodes = [];
+        foreach ($nodes as $node) {
+            $this->addChildNode($node);
+        }
     }
 
     /**
@@ -86,5 +106,30 @@ trait NodeTrait
         foreach ($nodes as $node) {
             $fn($node);
         }
+    }
+
+    /**
+     * Remove the given node from the tree
+     *
+     * @param NodeInterface $node
+     * @param NodeInterface|null
+     */
+    public function removeNode(NodeInterface $node)
+    {
+        $children = $this->getChildNodes();
+        $filtered = [];
+
+        foreach ($children as $child) {
+            if ($child !== $node) {
+                $filtered[] = $child;
+            }
+        }
+
+        if (count($filtered) !== count($children)) {
+            $this->setChildNodes($filtered);
+            return $node;
+        }
+
+        return null;
     }
 }

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -10,7 +10,7 @@ namespace Peridot\Core;
 trait NodeTrait
 {
     /**
-     * @return TestInterface
+     * @return NodeInterface
      */
     public function getNode()
     {

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -15,6 +15,11 @@ trait NodeTrait
     protected $childNodes = [];
 
     /**
+     * @var NodeInterface
+     */
+    protected $parent;
+
+    /**
      * @return NodeInterface
      */
     public function getNode()
@@ -28,6 +33,27 @@ trait NodeTrait
     public function getChildNodes()
     {
         return $this->childNodes;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return NodeInterface
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param  NodeInterface $parent
+     * @return mixed|void
+     */
+    public function setParent(TestInterface $parent)
+    {
+        $this->parent = $parent;
     }
 
     /**

--- a/src/Suite.php
+++ b/src/Suite.php
@@ -34,6 +34,14 @@ class Suite extends AbstractTest
     }
 
     /**
+     * @return NodeInterface[]
+     */
+    public function getChildNodes()
+    {
+        return $this->tests;
+    }
+
+    /**
      * Return collection of tests
      *
      * @return array

--- a/src/Suite.php
+++ b/src/Suite.php
@@ -9,13 +9,6 @@ namespace Peridot\Core;
 class Suite extends AbstractTest
 {
     /**
-     * Tests belonging to this suite
-     *
-     * @var array
-     */
-    protected $tests = [];
-
-    /**
      * Has the suite been halted
      *
      * @var bool
@@ -29,26 +22,17 @@ class Suite extends AbstractTest
      */
     public function addTest(TestInterface $test)
     {
-        $test->setParent($this);
-        $this->tests[] = $test;
-    }
-
-    /**
-     * @return NodeInterface[]
-     */
-    public function getChildNodes()
-    {
-        return $this->tests;
+        $this->addChildNode($test);
     }
 
     /**
      * Return collection of tests
      *
-     * @return array
+     * @return TestInterface[]
      */
     public function getTests()
     {
-        return $this->tests;
+        return $this->getChildNodes();
     }
 
     /**
@@ -58,7 +42,7 @@ class Suite extends AbstractTest
      */
     public function setTests(array $tests)
     {
-        $this->tests = $tests;
+        $this->setChildNodes($tests);
     }
 
     /**
@@ -82,7 +66,7 @@ class Suite extends AbstractTest
         $this->eventEmitter->emit('suite.start', $this);
         $this->eventEmitter->on('suite.halt', [$this, 'halt']);
 
-        foreach ($this->tests as $test) {
+        foreach ($this->childNodes as $test) {
 
             if ($this->halted) {
                 break;

--- a/src/Test.php
+++ b/src/Test.php
@@ -55,7 +55,7 @@ class Test extends AbstractTest
      */
     protected function runSetup()
     {
-        $this->forEachNodeTopDown(function (TestInterface $node) {
+        $this->walkDown(function (TestInterface $node) {
             $setups = $node->getSetupFunctions();
             foreach ($setups as $setup) {
                 call_user_func($setup);
@@ -72,7 +72,7 @@ class Test extends AbstractTest
      */
     protected function runTearDown(TestResult $result, $action)
     {
-        $this->forEachNodeBottomUp(function (TestInterface $test) use ($result, &$action) {
+        $this->walkUp(function (TestInterface $test) use ($result, &$action) {
             $tearDowns = $test->getTearDownFunctions();
             foreach ($tearDowns as $tearDown) {
                 try {

--- a/src/TestInterface.php
+++ b/src/TestInterface.php
@@ -122,7 +122,7 @@ interface TestInterface
      *
      * @param callable $fn
      */
-    public function forEachNodeBottomUp(callable $fn);
+    public function walkUp(callable $fn);
 
     /**
      * Execute a callback for each node in this test, starting
@@ -130,7 +130,7 @@ interface TestInterface
      *
      * @param callable $fn
      */
-    public function forEachNodeTopDown(callable $fn);
+    public function walkDown(callable $fn);
 
     /**
      * Set arguments to be passed to the test definition when invoked.

--- a/src/TestInterface.php
+++ b/src/TestInterface.php
@@ -8,7 +8,7 @@ use Peridot\EventEmitterInterface;
  *
  * @package Peridot\Core
  */
-interface TestInterface
+interface TestInterface extends NodeInterface
 {
     /**
      * @param  TestResult $result
@@ -55,17 +55,6 @@ interface TestInterface
      * @return callable
      */
     public function getDefinition();
-
-    /**
-     * @return TestInterface
-     */
-    public function getParent();
-
-    /**
-     * @param  TestInterface $parent
-     * @return mixed
-     */
-    public function setParent(TestInterface $parent);
 
     /**
      * Returns the full description including parent descriptions
@@ -115,22 +104,6 @@ interface TestInterface
      * @return EventEmitterInterface
      */
     public function getEventEmitter();
-
-    /**
-     * Execute a callback for each node in this test, starting
-     * at the bottom of the tree.
-     *
-     * @param callable $fn
-     */
-    public function walkUp(callable $fn);
-
-    /**
-     * Execute a callback for each node in this test, starting
-     * at the top of the tree.
-     *
-     * @param callable $fn
-     */
-    public function walkDown(callable $fn);
 
     /**
      * Set arguments to be passed to the test definition when invoked.


### PR DESCRIPTION
This PR introduces a formal concept of test hierarchies as tree structures. This has always been the case, but it has now been introduced as a first class citizen via the `NodeInterface` and `NodeTrait`.

`TestInterface` now extends `NodeInterface`, and all parent/child relationships are handled within this context. 

The method of interest here is really `NodeInterface::removeNode` - as this should allow tests to be removed from the hierarchy prior to execution. The impetus for this feature comes from https://github.com/peridot-php/peridot/issues/156 

The idea being plugins have an extension point to remove nodes from the normal test flow and do other things with them, i.e process isolation.