### PR TITLE
Feature - node filter

### DIFF
--- a/specs/node.spec.php
+++ b/specs/node.spec.php
@@ -58,20 +58,32 @@ describe('NodeInterface', function () {
     });
 
     describe('->filter()', function () {
-        it('should return a filtered node based on the given predicate', function () {
-            $fast = new Test('should run @fast');
-            $slow1 = new Test('should run @slow');
-            $slow2 = new Test('should also be @slow');
-            $this->node->setChildNodes([$fast, $slow1, $slow2]);
+        beforeEach(function () {
+            $this->fast = new Test('should run @fast');
+            $this->slow1 = new Test('should run @slow');
+            $this->slow2 = new Test('should also be @slow');
+            $this->node->setChildNodes([$this->fast, $this->slow1, $this->slow2]);
+        });
 
+        it('should return a filtered node based on the given predicate', function () {
             $filtered = $this->node->filter(function (TestInterface $test) {
                 return (bool) preg_match('/@slow/', $test->getDescription());
             });
             $children = $filtered->getChildNodes();
 
             assert(count($children) === 2, 'should have filtered out 1 child');
-            assert($children[0] === $slow1);
-            assert($children[1] === $slow2);
+            assert($children[0] === $this->slow1);
+            assert($children[1] === $this->slow2);
+        });
+
+        it('should allow inversion of the predicate condition', function () {
+            $filtered = $this->node->filter(function (TestInterface $test) {
+                return (bool) preg_match('/@slow/', $test->getDescription());
+            }, true);
+            $children = $filtered->getChildNodes();
+
+            assert(count($children) === 1, 'should have filtered out 2 children');
+            assert($children[0] === $this->fast);
         });
     });
 

--- a/specs/node.spec.php
+++ b/specs/node.spec.php
@@ -1,6 +1,7 @@
 <?php
 use Peridot\Core\Suite;
 use Peridot\Core\Test;
+use Peridot\Core\TestInterface;
 
 describe('NodeInterface', function () {
 
@@ -37,6 +38,40 @@ describe('NodeInterface', function () {
 
             assert($removed === $first, 'should have returned removed node');
             assert(count($this->node->getChildNodes()) === 1, 'size should reflect removed node');
+        });
+    });
+
+    describe('->walk()', function () {
+        it('should walk a hierarchy', function () {
+            $childSuite = new Suite('child suite');
+            $grandChildTest = new Test(' grand child');
+            $childSuite->addChildNode($grandChildTest);
+            $this->node->addChildNode($childSuite);
+
+            $joined = '';
+            $this->node->walk(function (TestInterface $test) use (&$joined) {
+                $joined .= $test->getDescription();
+            });
+
+            assert($joined === 'child suite grand child');
+        });
+    });
+
+    describe('->filter()', function () {
+        it('should return a filtered node based on the given predicate', function () {
+            $fast = new Test('should run @fast');
+            $slow1 = new Test('should run @slow');
+            $slow2 = new Test('should also be @slow');
+            $this->node->setChildNodes([$fast, $slow1, $slow2]);
+
+            $filtered = $this->node->filter(function (TestInterface $test) {
+                return (bool) preg_match('/@slow/', $test->getDescription());
+            });
+            $children = $filtered->getChildNodes();
+
+            assert(count($children) === 2, 'should have filtered out 1 child');
+            assert($children[0] === $slow1);
+            assert($children[1] === $slow2);
         });
     });
 

--- a/specs/runner.spec.php
+++ b/specs/runner.spec.php
@@ -192,5 +192,30 @@ describe("Runner", function() {
             $old = set_error_handler(function($n,$s,$f,$l) {});
             assert($handler === $old, "runner should have restored previous handler");
         });
+
+        context('when using a grep pattern', function () {
+            it('should only run tests with matching titles', function () {
+                $slowRan = null;
+                $fastRan = null;
+                $suite = new Suite('parent', function () {});
+
+                $slow = new Test('child @slow', function () use (&$slowRan) {
+                    $slowRan = true;
+                });
+                $fast = new Test('child @fast', function () use (&$fastRan) {
+                    $fastRan = true;
+                });
+
+                $suite->addTest($slow);
+                $suite->addTest($fast);
+                $runner = new Runner($suite, $this->eventEmitter);
+                $runner->setGrepPattern('@slow');
+
+                $runner->run(new TestResult(new EventEmitter()));
+
+                assert($slowRan, 'slow test should have been run');
+                assert($fastRan === null, 'fast test should not have been run');
+            });
+        });
     });
 });

--- a/src/NodeInterface.php
+++ b/src/NodeInterface.php
@@ -79,7 +79,8 @@ interface NodeInterface
      * the given predicate
      *
      * @param callable $predicate
+     * @param bool $invert
      * @return NodeInterface
      */
-    public function filter(callable $predicate);
+    public function filter(callable $predicate, $invert);
 }

--- a/src/NodeInterface.php
+++ b/src/NodeInterface.php
@@ -10,20 +10,27 @@ namespace Peridot\Core;
 interface NodeInterface
 {
     /**
-     * Execute a callback for each child node, starting
-     * at the bottom of the tree.
+     * Execute a callback for each node until the current node is reached, starting
+     * at the current node
      *
      * @param callable $fn
      */
     public function walkUp(callable $fn);
 
     /**
-     * Execute a callback for each child node, starting
-     * at the top of the tree.
+     * Execute a callback for each parent node until the current node is reached, starting
+     * at the oldest ancestor of the current node
      *
      * @param callable $fn
      */
     public function walkDown(callable $fn);
+
+    /**
+     * Execute a callback for every descendant of the current node
+     *
+     * @param callable $fn
+     */
+    public function walk(callable $fn);
 
     /**
      * Get the parent node
@@ -66,4 +73,13 @@ interface NodeInterface
      * @return NodeInterface|null
      */
     public function removeNode(NodeInterface $node);
+
+    /**
+     * Return a new structure with nodes matching
+     * the given predicate
+     *
+     * @param callable $predicate
+     * @return NodeInterface
+     */
+    public function filter(callable $predicate);
 }

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -153,12 +153,13 @@ trait NodeTrait
      * the given predicate
      *
      * @param callable $predicate
+     * @param bool $invert
      * @return NodeInterface
      */
-    public function filter(callable $predicate)
+    public function filter(callable $predicate, $invert = false)
     {
-        $this->walk(function (NodeInterface $node) use ($predicate) {
-            if (! $predicate($node)) {
+        $this->walk(function (NodeInterface $node) use ($predicate, $invert) {
+            if ($predicate($node) === $invert) {
                 $this->removeNode($node);
             }
         });

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -109,6 +109,21 @@ trait NodeTrait
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @param callable $fn
+     */
+    public function walk(callable $fn)
+    {
+        $children = $this->getNode()->getChildNodes();
+
+        foreach ($children as $child) {
+            $fn($child);
+            $child->walk($fn);
+        }
+    }
+
+    /**
      * Remove the given node from the tree
      *
      * @param NodeInterface $node
@@ -131,5 +146,22 @@ trait NodeTrait
         }
 
         return null;
+    }
+
+    /**
+     * Return a new structure with nodes matching
+     * the given predicate
+     *
+     * @param callable $predicate
+     * @return NodeInterface
+     */
+    public function filter(callable $predicate)
+    {
+        $this->walk(function (NodeInterface $node) use ($predicate) {
+            if (! $predicate($node)) {
+                $this->removeNode($node);
+            }
+        });
+        return $this;
     }
 }

--- a/src/RunnerInterface.php
+++ b/src/RunnerInterface.php
@@ -36,7 +36,8 @@ interface RunnerInterface
      * matching the pattern will be included in the test run
      *
      * @param string $pattern
+     * @param bool $invert
      * @return void
      */
-    public function setGrepPattern($pattern);
+    public function setGrepPattern($pattern, $invert);
 }

--- a/src/RunnerInterface.php
+++ b/src/RunnerInterface.php
@@ -30,4 +30,13 @@ interface RunnerInterface
      * @return bool
      */
     public function shouldStopOnFailure();
+
+    /**
+     * Set a pattern used to grep test descriptions. Tests with titles
+     * matching the pattern will be included in the test run
+     *
+     * @param string $pattern
+     * @return void
+     */
+    public function setGrepPattern($pattern);
 }


### PR DESCRIPTION
This PR introduces the ability to filter nodes based on a predicate. You may optionally invert the expression to catch cases where you want the opposite of what the predicate matches.

* Adds `NodeInterface::filter(callable $predicate, $invert = false)`
* Adds `RunnerInterface::setGrepPattern(string $pattern, $invert = false)`

The idea is that a `Runner` can filter which nodes it runs by matching the pattern against `TestInterface::getTitle()` where `TestInterface` will always be a `Test` (no suites included in match)

This would be useful for annotating tests:

```php
describe('Thing', function () {
    it('should run @slow');
    it('should run @fast');
    it('should also be @slow');
});
```

Isolating the slow tests would be doing the following on the runner instance:

```php
$runner->setGrepPattern('@slow');

// or isolate things that are not slow
$runner->setGrepPattern('@slow', true);
```

The intention is to expose the following switches to the cli:

```
--grep -g          a pattern to filter test titles
--invert -i        invert the grep pattern
--file-pattern     a grep expression for filtering what files to run
```

The current implementation of `--grep` would be replaced with `--file-pattern`

fixes https://github.com/peridot-php/peridot/issues/114

