### PR TITLE
Scope state resolution

### DIFF
--- a/specs/suite.spec.php
+++ b/specs/suite.spec.php
@@ -55,7 +55,7 @@ describe("Suite", function() {
 
         it('should pass child scopes to tests', function() {
             $suite = new Suite("Suite", function() {});
-            $suite->getScope()->addChildScope(new SuiteScope());
+            $suite->getScope()->use(new SuiteScope());
             $test = new Test("this is a test", function() {
                 assert($this->getNumber() == 5, "parent scope should be set on test");
             });

--- a/src/Behavior/Listener.php
+++ b/src/Behavior/Listener.php
@@ -44,6 +44,6 @@ class Listener
     {
         $scope = $test->getScope();
         $behavior = new StateBehavior($test);
-        $scope->addChildScope($behavior);
+        $scope->use($behavior);
     }
 }

--- a/src/Scope/AbstractResolver.php
+++ b/src/Scope/AbstractResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Peridot\Core\Scope;
+
+use Peridot\Core\Scope;
+
+/**
+ * Class AbstractResolver
+ *
+ * @package Peridot\Core\Scope
+ */
+class AbstractResolver
+{
+    /**
+     * @var Scope
+     */
+    protected $scope;
+
+    /**
+     * @param Scope $scope
+     */
+    public function __construct(Scope $scope)
+    {
+        $this->scope = $scope;
+    }
+
+    /**
+     * Scan child scopes and execute a function against each one passing an
+     * accumulator reference along.
+     *
+     * @param Scope $scope
+     * @param callable $fn
+     * @param array $accumulator
+     * @return array
+     */
+    protected function scanChildren(Scope $scope, callable $fn, &$accumulator = [])
+    {
+        if (! empty($accumulator)) {
+            return $accumulator;
+        }
+
+        $children = $scope->getChildScopes();
+        foreach ($children as $childScope) {
+            $fn($childScope, $accumulator);
+            $this->scanChildren($childScope, $fn, $accumulator);
+        }
+        return $accumulator;
+    }
+}

--- a/src/Scope/MethodResolver.php
+++ b/src/Scope/MethodResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Peridot\Core\Scope;
+
+/**
+ * MethodResolver is responsible for resolving methods from a scope chain
+ *
+ * @package Peridot\Core\Scope
+ */
+class MethodResolver extends AbstractResolver
+{
+    /**
+     * Resolve a scope method
+     *
+     * @param $name
+     * @param $arguments
+     * @return ResolutionResult
+     */
+    public function resolve($name, $arguments)
+    {
+        list($result, $found) = $this->resolveParent($name, $arguments);
+
+        if ($found) {
+            return new ResolutionResult($result, $found);
+        }
+
+        list($result, $found) = $this->scanChildren($this->scope, function ($childScope, &$accumulator) use ($name, $arguments) {
+            if (method_exists($childScope, $name)) {
+                $accumulator = [call_user_func_array([$childScope, $name], $arguments), true];
+            }
+        });
+
+        return new ResolutionResult($result, $found);
+    }
+
+    /**
+     * Check the scope's parent for a method
+     *
+     * @param $name
+     * @return mixed|null
+     */
+    protected function resolveParent($name, $arguments)
+    {
+        $parent = $this->scope->getParentScope();
+
+        while ($parent !== null) {
+            if (method_exists($parent, $name)) {
+                return [call_user_func_array([$parent, $name], $arguments), true];
+            }
+            $parent = $parent->getParentScope();
+        }
+
+        return [null, false];
+    }
+}

--- a/src/Scope/PropertyResolver.php
+++ b/src/Scope/PropertyResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Peridot\Core\Scope;
+
+use Peridot\Core\Scope;
+
+/**
+ * PropertyResolver is responsible for resolving property values from a scope chain
+ *
+ * @package Peridot\Core\Scope
+ */
+class PropertyResolver extends AbstractResolver
+{
+    /**
+     * Resolve a scope property
+     *
+     * @param $name
+     * @return ResolutionResult
+     */
+    public function resolve($name)
+    {
+        list($result, $found) = $this->resolveParent($name);
+
+        if ($found) {
+            return new ResolutionResult($result, $found);
+        }
+
+        list($result, $found) = $this->scanChildren($this->scope, function ($childScope, &$accumulator) use ($name) {
+            if (property_exists($childScope, $name)) {
+                $accumulator = [$childScope->$name, true, $childScope];
+            }
+        });
+
+        return new ResolutionResult($result, $found);
+    }
+
+    /**
+     * Check the scope's parent for a property value
+     *
+     * @param $name
+     * @return mixed|null
+     */
+    protected function resolveParent($name)
+    {
+        $parent = $this->scope->getParentScope();
+
+        while ($parent !== null) {
+            if (property_exists($parent, $name)) {
+                return [$parent->$name, true];
+            }
+            $parent = $parent->getParentScope();
+        }
+
+        return [null, false];
+    }
+}

--- a/src/Scope/ResolutionResult.php
+++ b/src/Scope/ResolutionResult.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Peridot\Core\Scope;
+
+/**
+ * ResolutionResult is a simple data structure for encapsulating
+ * the results of resolving a value on a Scope
+ *
+ * @package Peridot\Core\Scope
+ */
+class ResolutionResult
+{
+    /**
+     * @var mixed
+     */
+    public $value;
+
+    /**
+     * @var bool
+     */
+    public $found;
+
+    /**
+     * @param mixed $value
+     * @param bool $found
+     */
+    public function __construct($value, $found = true)
+    {
+        $this->value = $value;
+        $this->found = (bool) $found;
+    }
+}


### PR DESCRIPTION
fixes #12 

This PR allows `Scope` objects to resolve methods and properties both up and down the scope chain. I think this brings Scopes closer in line to traits, and makes them generally more useful.

Resolution first attempts to resolve a property or method against a parent scope, then attempts to resolve them against children.

This PR also renames the mechanism for mixing in child scopes. Instead of `->addChildScope()`, it is now `->mixin()`. A `__call` style alias has been provided to `mixin` as well, allowing `->use()` as well.